### PR TITLE
Explicitly become root for OS package installs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,8 @@
     - default.yml
 
 - name: Install rustup system requirements
+  become: true
+  become_user: root
   package:
     name: "{{ item }}"
     state: present


### PR DESCRIPTION
I don't blanket become root for all of my ansible roles so I fail to install these dependencies