### PR TITLE
Add required configuration for supporting macOS

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,9 @@ galaxy_info:
    - name: Archlinux
      versions:
        - all
+   - name: macOS
+     versions:
+      - all
 
   galaxy_tags: [rustup, rust, cargo]
 

--- a/vars/macOS.yml
+++ b/vars/macOS.yml
@@ -1,0 +1,6 @@
+---
+rustup_packages:
+  - curl
+  - gcc
+  - make
+


### PR DESCRIPTION
Added variables and platform metadata for macOS. According to [this](https://github.com/dmsimard/ansible-sandbox/tree/master/get-galaxy-platforms), the platform identifier for the latest releases - let me know if that's incorrect. Thanks!