### PR TITLE
Fix usage of undefined rust_default_toolchain variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
 
     - name: Set specified toolchain version as default, implicitly installing if necessary
       ansible.builtin.import_tasks: set-toolchain.yml
-      when: rustup_exe is undefined or active_rustup_toolchain_version != rust_default_toolchain
+      when: rustup_exe is undefined or active_rustup_toolchain_version != rustup_default_version
 
     - name: Apply configuration (shellrc, etc.)
       ansible.builtin.import_tasks: configure.yml

--- a/tasks/set-toolchain.yml
+++ b/tasks/set-toolchain.yml
@@ -4,12 +4,12 @@
     argv:
       - rustup
       - default
-      - "{{ rust_default_toolchain }}"
+      - "{{ rustup_default_version }}"
   environment:
     RUSTUP_HOME: "{{ rustup_user_home }}/{{ rustup_home_suffix }}"
     CARGO_HOME: "{{ rustup_user_home }}/{{ rustup_cargo_home_suffix }}"
     PATH: "{{ ansible_env.PATH }}:{{ rustup_user_home }}/{{ rustup_cargo_home_suffix }}/bin"
-  when: active_rustup_toolchain_version is undefined or active_rustup_toolchain_version != rust_default_toolchain
+  when: active_rustup_toolchain_version is undefined or active_rustup_toolchain_version != rustup_default_version
 
 - name: Install cargo crates
   ansible.builtin.shell: |


### PR DESCRIPTION
On my installation ansible complains, that the rust_default_toolchain variable is undefined and I also do not see, where it is defined. OTOH `rustup_default_version` is defined in `default/main.yml` but is not used anywhere.

So I fixed this issue by using the `rustup_default_version` variable.