### PR TITLE
Fix checks for whether rustup is installed

### DIFF
--- a/tasks/gather-state.yml
+++ b/tasks/gather-state.yml
@@ -23,7 +23,7 @@
     RUSTUP_HOME: "{{ rustup_user_home }}/{{ rustup_home_suffix }}"
     CARGO_HOME: "{{ rustup_user_home }}/{{ rustup_cargo_home_suffix }}"
     PATH: "{{ ansible_env.PATH }}:{{ rustup_user_home }}/{{ rustup_cargo_home_suffix }}/bin"
-  when: rustup_exe_status is succeeded
+  when: rustup_exe_status.stat.exists
   changed_when: false
   ignore_errors: true
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,11 +30,11 @@
     # Set the path to the rustup
     - name: Download rustup
       ansible.builtin.import_tasks: get-rustup.yml
-      when: rustup_exe_status is failed
+      when: not rustup_exe_status.stat.exists
 
     - name: Set specified toolchain version as default, implicitly installing if necessary
       ansible.builtin.import_tasks: set-toolchain.yml
-      when: rustup_exe is undefined or active_rustup_toolchain_version != rust_default_toolchain
+      when: not rustup_exe_status.stat.exists or active_rustup_toolchain_version != rust_default_toolchain
 
     - name: Apply configuration (shellrc, etc.)
       ansible.builtin.import_tasks: configure.yml


### PR DESCRIPTION
* use `stat.exists` instead of `is succeded`
* `rustup_exe` is always defined

It seems the `stat` builtin `is succeeded` even when the target file does not exist:

```
TASK [hurricanehrndz.rustup : Check for presence of rustup executable]
ok: [server]

TASK [hurricanehrndz.rustup : rustup_exe_status] 
ok: [server] => {
    "msg": {
        "changed": false,
        "failed": false,
        "stat": {
            "exists": false
        }
    }
}
```

Note: I came up with these changes when addressing the same "variable undefined" error as in https://github.com/hurricanehrndz/ansible-rustup/pull/14